### PR TITLE
Add CloudflareProtectedEmailAddress

### DIFF
--- a/lib/cloudflare_protected_email_address.rb
+++ b/lib/cloudflare_protected_email_address.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'cgi'
+
+class CloudflareProtectedEmailAddress
+  def initialize(obfuscated)
+    @obfuscated = obfuscated
+  end
+
+  def human_readable
+    return obfuscated unless unescaped.include?('@')
+    unescaped
+  end
+
+  private
+
+  attr_accessor :obfuscated
+
+  def components
+    obfuscated.scan(/.{2}/).map(&:hex)
+  end
+
+  def obfuscated_characters
+    components.drop(1)
+  end
+
+  def key
+    components.first
+  end
+
+  def escaped
+    obfuscated_characters.map { |char| (char ^ key).to_s(16).prepend('%') }.join
+  end
+
+  def unescaped
+    CGI.unescape(escaped)
+  end
+end

--- a/lib/cloudflare_protected_email_address.rb
+++ b/lib/cloudflare_protected_email_address.rb
@@ -3,36 +3,32 @@
 require 'cgi'
 
 class CloudflareProtectedEmailAddress
-  def initialize(obfuscated)
-    @obfuscated = obfuscated
+  def initialize(obfuscated_address)
+    @obfuscated_address = obfuscated_address
   end
 
   def human_readable
-    return obfuscated unless unescaped.include?('@')
-    unescaped
+    return obfuscated_address unless unencoded_address.include?('@')
+    unencoded_address
   end
 
   private
 
-  attr_accessor :obfuscated
+  attr_accessor :obfuscated_address
 
-  def components
-    obfuscated.scan(/.{2}/).map(&:hex)
-  end
-
-  def obfuscated_characters
-    components.drop(1)
+  def obfuscated_address_as_integers
+    obfuscated_address.scan(/../).map(&:hex)
   end
 
   def key
-    components.first
+    obfuscated_address_as_integers.first
   end
 
-  def escaped
-    obfuscated_characters.map { |char| (char ^ key).to_s(16).prepend('%') }.join
+  def hex_encoded_address
+    obfuscated_address_as_integers.drop(1).map { |char| '%%%02X' % (char ^ key) }.join
   end
 
-  def unescaped
-    CGI.unescape(escaped)
+  def unencoded_address
+    CGI.unescape(hex_encoded_address)
   end
 end

--- a/test/cloudflare_protected_email_address_test.rb
+++ b/test/cloudflare_protected_email_address_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+require_relative '../lib/cloudflare_protected_email_address'
+
+describe CloudflareProtectedEmailAddress do
+  it 'will make an obfuscated email address human readable' do
+    CloudflareProtectedEmailAddress.new('b3d2dfd7dcc5d6c1d2f3d7dac3c6c7d2d7dcc09dd4dcc59dc3ca')
+                                   .human_readable
+                                   .must_equal 'aldovera@diputados.gov.py'
+  end
+
+  it 'returns the initialization email when it is not obfuscated' do
+    CloudflareProtectedEmailAddress.new('aldovera@diputados.gov.py')
+                                   .human_readable
+                                   .must_equal 'aldovera@diputados.gov.py'
+  end
+
+  it 'returns the original string when the initialization string is not an obfuscated email' do
+    CloudflareProtectedEmailAddress.new('xyz789')
+                                   .human_readable
+                                   .must_equal 'xyz789'
+  end
+end


### PR DESCRIPTION
This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/issues/34867

Member email addresses have been obfuscated and the scraper is currently capturing a string of javascript instead of the email address:

`:email=>"[email protected]/* <![CDATA[ */!function(t,e,r,n,c,a,p){try{t=document.currentScript||function(){for(t=document.getElementsByTagName('script'),e=t.length;e--;)if(t[e].getAttribute('data-cfhash'))return t[e]}();if(t&&(c=t.previousSibling)){p=t.parentNode;if(a=c.getAttribute('data-cfemail')){for(e='',r='0x'+a.substr(0,2)|0,n=2;a.length-n;n+=2)e+='%'+('0'+('0x'+a.substr(n,2)^r).toString(16)).slice(-2);p.replaceChild(document.createTextNode(decodeURIComponent(e)),c)}p.removeChild(t)}}catch(u){}}()/* ]]> */"`

 For example, when the obfuscated address is `b3d2dfd7dcc5d6c1d2f3d7dac3c6c7d2d7dcc09dd4dcc59dc3ca`, calling 
```ruby
CloudflareProtectedEmailAddress.new('b3d2dfd7dcc5d6c1d2f3d7dac3c6c7d2d7dcc09dd4dcc59dc3ca').human_readable
```
will return: 
`aldovera@diputados.gov.py`

The javascript comes from the Paraguay member pages. The key part is:
```
a.substr(n,2)^r
```

`r` is the first character of the input string. The remainder is the obfuscated email. Two digit hexadecimals represent each character.

The next step will be to use this class within `MemberPage`.

This method of obfuscation is not particular to this site. For example, it is being used on the New Zealand site https://github.com/everypolitician/everypolitician-data/issues/36492. The intention is to develop the class in this scraper before extracting it to a gem.